### PR TITLE
アプリがフォーカスされた時も24時間のチェックを行うように修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { Node } from "unist-util-visit";
+import { appWindow } from "@tauri-apps/api/window";
 import { unified, VFileWithOutput } from "unified";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -43,6 +44,24 @@ function App() {
   const [history, setHistory] = useState<Task[]>(
     getJsonParse(STORAGE_KEY.HISTORY)
   );
+
+  useEffect(() => {
+    let focusUnListen: () => void = () => {};
+    async function f() {
+      focusUnListen = await appWindow.listen(
+        "tauri://focus",
+        ({ event, payload }) => {
+          console.log("tauri://focus", event, payload);
+          addHistoryValue(markdown, tasks);
+        }
+      );
+    }
+    f();
+
+    return () => {
+      focusUnListen();
+    };
+  }, []);
 
   useListen({
     onImportCallback: (markdown, tTasks, history) => {

--- a/src/hooks/useListen.tsx
+++ b/src/hooks/useListen.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 const useListen = (props: Props) => {
   useEffect(() => {
-    let unListenAbout: any;
-    let unListenExport: any;
-    let unListenImport: any;
+    let unListenAbout: () => void = () => {};
+    let unListenExport: () => void = () => {};
+    let unListenImport: () => void = () => {};
     async function f() {
       unListenAbout = await listen<string>("about", () => {
         dialog.message("Copyright © 2022 wheatandcat", "This is a todo app.");
@@ -57,15 +57,9 @@ const useListen = (props: Props) => {
     f();
 
     return () => {
-      if (unListenAbout) {
-        unListenAbout();
-      }
-      if (unListenExport) {
-        unListenExport();
-      }
-      if (unListenImport) {
-        unListenImport();
-      }
+      unListenAbout();
+      unListenExport();
+      unListenImport();
     };
   }, []);
 

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,0 +1,39 @@
+{
+  "tauri": {
+    "allowlist": {
+      "window": {
+        "all": true,
+        "create": true,
+        "center": true,
+        "requestUserAttention": true,
+        "setResizable": true,
+        "setTitle": true,
+        "maximize": true,
+        "unmaximize": true,
+        "minimize": true,
+        "unminimize": true,
+        "show": true,
+        "hide": true,
+        "close": true,
+        "setDecorations": true,
+        "setAlwaysOnTop": true,
+        "setContentProtected": true,
+        "setSize": true,
+        "setMinSize": true,
+        "setMaxSize": true,
+        "setPosition": true,
+        "setFullscreen": true,
+        "setFocus": true,
+        "setIcon": true,
+        "setSkipTaskbar": true,
+        "setCursorGrab": true,
+        "setCursorVisible": true,
+        "setCursorIcon": true,
+        "setCursorPosition": true,
+        "setIgnoreCursorEvents": true,
+        "startDragging": true,
+        "print": true
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,9 +941,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
-  version "1.0.30001431"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
-  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
+  version "1.0.30001486"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz"
+  integrity sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==
 
 chai@^4.3.7:
   version "4.3.7"


### PR DESCRIPTION
## 関連 issue

- fixes #35

## 対応内容

- 24時間経つとタスクが消える機能があるがアプリを起動しっぱなしにして開いた場合にタスクが監視するように修正
- [window | Tauri Apps](https://tauri.app/v1/api/js/window/)を使用

## 開発用メモ

無し
