### PR TITLE
即座に履歴に送る機能を追加

### DIFF
--- a/e2e/todo.spec.ts
+++ b/e2e/todo.spec.ts
@@ -78,3 +78,33 @@ test.describe("Markdownの入力した時に、保存されるデータのチェ
     ]);
   });
 });
+
+
+test.describe("右クリックで直接履歴に追加", () => {
+  test("右クリックで履歴に追加", async ({ page }) => {
+    await mockDate(page, "2023-01-01T00:00:00+09:00");
+
+    await page.getByText("編集").click();
+
+    await page.locator("data-testid=input-markdown").click();
+    await page
+      .locator("data-testid=input-markdown")
+      .fill("- [ ] Task1\n- [ ] Task2\n- [ ] Task3");
+    await page.getByText("プレビュー").click();
+    await page.getByText("Task1").click({
+      button: "right",
+    });
+    await page.getByText('履歴に追加').click();
+
+    await page.getByText("編集").click();
+    expect(
+      await page.locator("data-testid=input-markdown").inputValue()
+    ).toMatch("- [ ] Task2\n- [ ] Task3");
+
+    await page.getByText('履歴').click();
+
+    const paragraph = page.locator("data-testid=history");
+    expect(await paragraph.textContent()).toBe("2023年01月01日 00:00Task1");
+
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dayjs": "^1.11.6",
     "markdown-to-jsx": "^7.1.8",
     "react": "^18.2.0",
+    "react-contexify": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "remark-parse": "^10.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,7 +141,12 @@ function App() {
   );
 
   const onChangeTask = useCallback(
-    (checked: boolean, taskText: string, nest: string[]) => {
+    (
+      checked: boolean,
+      taskText: string,
+      nest: string[],
+      directHistory: boolean = false
+    ) => {
       tasks = tasks.map((v) => {
         const text = getItemText(v.text);
         if (text === taskText) {
@@ -151,6 +156,10 @@ function App() {
             v.checkedAt = dayjs().add(0, "day").toString();
           } else {
             v.checkedAt = null;
+          }
+          if (directHistory) {
+            v.directHistory = true;
+            v.checkedAt = dayjs().add(0, "day").toString();
           }
         }
 
@@ -185,6 +194,11 @@ function App() {
         .join("\n");
 
       setMarkdown(m);
+
+      // 直接履歴に追加
+      if (directHistory) {
+        addHistoryValue(m, tasks);
+      }
     },
     [markdown]
   );

--- a/src/components/organisms/History.tsx
+++ b/src/components/organisms/History.tsx
@@ -23,7 +23,10 @@ function ErrorFallback({ error, resetErrorBoundary }: any) {
 
 const History: React.FC<Props> = (props) => {
   return (
-    <div className="border text-left mx-4 my-3 history overflow-y-scroll">
+    <div
+      className="border text-left mx-4 my-3 history overflow-y-scroll"
+      data-testid="history"
+    >
       {props.items.map((item, index) => {
         return (
           <div key={index} className="m-3 pt-1">

--- a/src/components/organisms/Preview.tsx
+++ b/src/components/organisms/Preview.tsx
@@ -1,16 +1,69 @@
 import React, { memo } from "react";
 import Markdown from "markdown-to-jsx";
+import {
+  Menu,
+  Item,
+  useContextMenu,
+  TriggerEvent,
+  ItemParams,
+} from "react-contexify";
+import "react-contexify/ReactContexify.css";
 import { getTaskText } from "../../lib/task";
 import List from "./List";
 
 type Props = {
   markdown: string;
-  onChangeTask: (checked: boolean, taskText: string, nest: string[]) => void;
+  onChangeTask: (
+    checked: boolean,
+    taskText: string,
+    nest: string[],
+    directHistory?: boolean
+  ) => void;
 };
 
+const MENU_ID = "context-menu";
+
 const Preview: React.FC<Props> = ({ markdown, onChangeTask }) => {
+  const { show } = useContextMenu({
+    id: MENU_ID,
+  });
+
+  const handleContextMenu = (
+    event: TriggerEvent,
+    taskText: string,
+    nest: string[]
+  ) => {
+    show({
+      event,
+      props: {
+        taskText,
+        nest,
+      },
+    });
+  };
+
+  const handleItemClick = ({ id, props }: ItemParams) => {
+    switch (id) {
+      case "remove":
+        console.log("remove", props);
+        onChangeTask(true, props.taskText, props.nest, true);
+        break;
+    }
+  };
+
   return (
     <div className="border text-left px-5 py-4 mx-4 my-3 board overflow-y-scroll">
+      <div>
+        <Menu id={MENU_ID}>
+          <Item
+            id="remove"
+            onClick={handleItemClick}
+            data-testid="context-menu-remove"
+          >
+            履歴に追加
+          </Item>
+        </Menu>
+      </div>
       <Markdown
         data-testid="preview"
         options={{
@@ -70,7 +123,11 @@ const Preview: React.FC<Props> = ({ markdown, onChangeTask }) => {
                         </div>
                         <div>
                           <label htmlFor={id}>
-                            <span>
+                            <span
+                              onContextMenu={(e) =>
+                                handleContextMenu(e, taskText, nest)
+                              }
+                            >
                               {isLink ? (
                                 <a href={taskText} target="_blank">
                                   {taskText}

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -9,6 +9,7 @@ export type Task = {
   checked: boolean;
   nest?: string[];
   checkedAt: string | null;
+  directHistory?: boolean;
 };
 
 export const getTasks = (root: Node, tTasks: Task[]) => {
@@ -71,9 +72,15 @@ export const getHistory = (tTasks: Task[]) => {
       return false;
     }
 
-    const ok = dayjs().diff(dayjs(v.checkedAt), "hour") > 12;
+    if (dayjs().diff(dayjs(v.checkedAt), "hour") > 12) {
+      return true
+    }
 
-    return ok;
+    if (v.directHistory) {
+      return true;
+    }
+    
+    return false;
   });
 
   return h;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
@@ -2506,6 +2511,13 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+react-contexify@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-contexify/-/react-contexify-6.0.0.tgz#52959bb507d6a31224fe870ae147e211e359abe1"
+  integrity sha512-jMhz6yZI81Jv3UDj7TXqCkhdkCFEEmvwGCPXsQuA2ZUC8EbCuVQ6Cy8FzKMXa0y454XTDClBN2YFvvmoFlrFkg==
+  dependencies:
+    clsx "^1.2.1"
 
 react-dom@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## 関連 issue

- fixes #22

## 対応内容

<img width="480" alt="スクリーンショット 2023-05-14 18 29 09" src="https://github.com/wheatandcat/todo/assets/19209314/983a27b3-8870-4984-94f1-58a004b345e1">

 - 項目に右クリックで即座に履歴に登録出来る機能を追加
 - [fkhadra/react-contexify: 👌 Add a context menu to your react app with ease](https://github.com/fkhadra/react-contexify)を使用して実装
 - e2eのテストケースも追加


## 開発用メモ

無し
